### PR TITLE
initial version

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,124 @@
+# Style file for MLSE Libraries based on the modified rocBLAS style
+
+# Common settings
+BasedOnStyle:  WebKit
+TabWidth:        4
+IndentWidth:     4
+UseTab:          Never
+ColumnLimit: 100
+
+# Other languages JavaScript, Proto
+
+---
+Language: Cpp
+
+# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
+# int formatted_code;
+# // clang-format off
+#     void    unformatted_code  ;
+# // clang-format on
+# void formatted_code_again;
+
+DisableFormat:   false
+Standard: Cpp11
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterCaseLabel: 'true'
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+#    AfterExternBlock : 'true'
+}
+
+#BreakAfterJavaFieldAnnotations: true
+#BreakBeforeInheritanceComma: false
+#BreakBeforeBinaryOperators: None
+#BreakBeforeTernaryOperators: true
+#BreakConstructorInitializersBeforeComma: true
+#BreakStringLiterals: true
+
+CommentPragmas:  '^ IWYU pragma:'
+#CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IndentCaseLabels: false
+IndentPPDirectives: None
+#FixNamespaceComments: true
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+#JavaScriptQuotes: Double
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 4
+#ObjCSpaceAfterProperty: true
+#ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+#SpaceAfterTemplateKeyword: true
+#SpaceBeforeInheritanceColon: true
+
+#SortUsingDeclarations: true
+SortIncludes: true
+
+# Comments are for developers, they should arrange them
+ReflowComments: false
+
+#IncludeBlocks: Preserve
+---

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,30 @@
+;; This causes emacs to abide by formatting rules: No tab characters, except
+;; in Makefiles; BSD-style indendation, with a 4-character indentation offset
+;; (8 in assembly code and Makefiles); no whitespace at the end of lines; and
+;; a newline at the end of file.
+
+(
+ (nil . (
+  (require-final-newline . t)
+  (indent-tabs-mode . nil)
+  (eval add-hook 'before-save-hook 'delete-trailing-whitespace)
+  (eval add-hook 'before-save-hook (lambda () (untabify (point-min) (point-max))))
+ ) )
+ (prog-mode . (
+  (tab-width . 4)
+  (c-basic-offset . 4)
+  (c-file-style . "bsd")
+ ) )
+ (asm-mode . (
+  (tab-width . 8)
+ ) )
+ (makefile-mode . (
+  (indent-tabs-mode . t)
+  (tab-width . 8)
+  (eval remove-hook `before-save-hook (lambda () (untabify (point-min) (point-max))))
+ ) )
+ (fundamental-mode . (
+  (eval require 'yaml-mode)
+  (eval set-auto-mode t)
+  ) )
+)

--- a/.githooks/install
+++ b/.githooks/install
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --git-dir)
+cd hooks
+
+echo "Installing hooks..."
+ln -s ../../.githooks/pre-commit pre-commit
+echo "Done!"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# This pre-commit hook checks if any versions of clang-format
+# are installed, and if so, uses the installed version to format
+# the staged changes.
+
+export PATH=/usr/bin:/bin
+
+set -x
+
+format=/opt/rocm/hcc/bin/clang-format
+
+# Redirect stdout to stderr.
+exec >&2
+
+# Do everything from top - level
+cd $(git rev-parse --show-toplevel)
+
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+if [[ "$1" == "--reformat" ]]; then
+    files=$(git ls-files --exclude-standard)
+else
+    files=$(git diff-index --cached --name-only $against)
+fi
+
+[[ -z "$files" ]] && exit
+
+# Change the copyright date at the top of any text files
+for file in $files; do
+    if [[ -e $file ]]; then
+        /usr/bin/perl -pi -e 'INIT { exit 1 if !-f $ARGV[0] || -B $ARGV[0]; $year = (localtime)[5] + 1900 }
+            s/^([*\/#[:space:]]*)Copyright\s+(?:\(C\)\s*)?(\d+)(?:\s*-\s*\d+)?/qq($1Copyright $2@{[$year != $2 ? "-$year" : ""]})/ie
+            if $. < 10' "$file" && git add -u "$file"
+    fi
+done
+
+# do the formatting
+for file in $files; do
+    if [[ -e $file ]] && echo $file | grep -Eq '\.c$|\.h$|\.hpp$|\.cpp$|\.cl$|\.in$|\.txt$|\.yaml$|\.sh$|\.py$|\.pl$|\.cmake$|\.md$|\.rst$|\.groovy$'; then
+        sed -i -e 's/[[:space:]]*$//' "$file" # Remove whitespace at end of lines
+        sed -i -e '$a\' "$file" # Add missing newline to end of file
+        # Convert UTF8 non-ASCII to ASCII
+        temp=$(mktemp)
+        [[ -w $temp ]] || exit
+        iconv -s -f utf-8 -t ascii//TRANSLIT "$file" > "$temp" || exit
+        chmod --reference="$file" "$temp" || exit
+        mv -f "$temp" "$file" || exit
+        git add -u "$file"
+    fi
+done
+
+# if clang-format exists, run it on C/C++ files
+if [[ -x $format ]]; then
+    for file in $files; do
+       if [[ -e $file ]] && echo $file | grep -Eq '\.c$|\.h$|\.hpp$|\.cpp$|\.cl$|\.h\.in$|\.hpp\.in$|\.cpp\.in$'; then
+            echo "$format $file"
+            "$format" -i -style=file "$file"
+            git add -u "$file"
+        fi
+    done
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,11 @@
 # Prerequisites
 *.d
 
-# Object files
+# Compiled Object files
 *.o
 *.ko
 *.obj
 *.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
 
 # Precompiled Headers
 *.gch
@@ -19,34 +14,45 @@
 # Libraries
 *.lib
 *.a
+
+# Compiled Static libraries
+*.lai
 *.la
+*.a
+*.lib
 *.lo
 
-# Shared objects (inc. Windows DLLs)
-*.dll
+# Compiled Dynamic libraries
 *.so
 *.so.*
 *.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Linker output
+*.ilk
+*.map
+*.exp
 
 # Executables
 *.exe
 *.out
 *.app
-*.i*86
-*.x86_64
-*.hex
 
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
+# vim tags
+tags
+.tags
+.*.swp
 
-# Kernel Module Compile Results
-*.mod*
-*.cmd
-.tmp_versions/
-modules.order
-Module.symvers
-Mkfile.old
-dkms.conf
+# Editors
+.vscode
+
+# build-in-source directory
+build*
+
+# emacs temporary/backup files
+.\#*
+\#*\#
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,114 @@
+# MIT License
+#
+# Copyright 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+
+# Install prefix
+set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix, prepended onto install directories")
+
+# rocPRIM project
+project(roclibutils LANGUAGES CXX)
+
+# CMake modules
+list(APPEND CMAKE_MODULE_PATH
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake
+  ${HIP_PATH}/cmake /opt/rocm/hip/cmake # FindHIP.cmake
+)
+
+# Set a default build type if none was specified
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "Add paths to linker search and installed rpath")
+
+# Verify that hcc compiler is used on ROCM platform
+include(cmake/VerifyCompiler.cmake)
+
+# Build option to disable -Werror
+option(DISABLE_WERROR "Disable building with Werror" ON)
+
+# Set CXX flags
+set_target_properties( rocblas PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON )
+if(DISABLE_WERROR)
+  target_compile_options( rocblas PRIVATE -Wall -Wextra )
+else()
+  target_compile_options( rocblas PRIVATE -Wall -Wextra -Werror )
+endif()
+
+# Build options
+option(BUILD_TEST "Build tests (requires googletest)" ON)
+option(BUILD_BENCHMARK "Build benchmarks" OFF)
+option(BUILD_EXAMPLE "Build examples" OFF)
+# Disables building tests, benchmarks, examples
+option(ONLY_INSTALL "Only install" OFF)
+
+# Get dependencies
+include(cmake/Dependencies.cmake)
+
+# AMD targets
+set(AMDGPU_TARGETS gfx803;gfx900;gfx906;gfx908 CACHE STRING "List of specific machine types for library to target")
+
+# Setup VERSION
+set(VERSION_STRING "2.10.0")
+rocm_setup_version(VERSION ${VERSION_STRING})
+
+# Print configuration summary
+include(cmake/Summary.cmake)
+print_configuration_summary()
+
+# roclibutilslibrary
+add_subdirectory(roclibutils)
+
+# Tests
+if(BUILD_TEST AND NOT ONLY_INSTALL)
+  enable_testing()
+  add_subdirectory(test)
+endif()
+
+# Benchmarks
+if(BUILD_BENCHMARK AND NOT ONLY_INSTALL)
+  add_subdirectory(benchmark)
+endif()
+
+# Examples
+if(BUILD_EXAMPLE AND NOT ONLY_INSTALL)
+  add_subdirectory(example)
+endif()
+
+# Package
+
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-dev (>= 2.5.27)")
+set(CPACK_RPM_PACKAGE_REQUIRES "rocm-dev >= 2.5.27")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
+if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
+  set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" )
+
+rocm_create_package(
+  NAME roclibutils
+  DESCRIPTION "Radeon Open Compute Library Utilities"
+)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 ROCm Software Platform 
+Copyright 2019-2020 ROCm Software Platform 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,0 +1,126 @@
+# MIT License
+#
+# Copyright 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ###########################
+# roclibutils dependencies
+# ###########################
+
+# HIP dependency is handled earlier in the project cmake file
+# when VerifyCompiler.cmake is included.
+
+# For downloading, building, and installing required dependencies
+include(cmake/DownloadProject.cmake)
+
+# Never update automatically from the remote repository
+if(CMAKE_VERSION VERSION_LESS 3.2)
+  set(UPDATE_DISCONNECTED_IF_AVAILABLE "")
+else()
+  set(UPDATE_DISCONNECTED_IF_AVAILABLE "UPDATE_DISCONNECTED TRUE")
+endif()
+
+# GIT
+find_package(Git REQUIRED)
+if (NOT Git_FOUND)
+  message(FATAL_ERROR "Please ensure Git is installed on the system")
+endif()
+
+# Test dependencies
+if(BUILD_TEST)
+  # Google Test (https://github.com/google/googletest)
+  message(STATUS "Downloading and building GTest.")
+  set(GTEST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/gtest CACHE PATH "")
+  download_project(
+    PROJ           googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        release-1.8.1
+    INSTALL_DIR    ${GTEST_ROOT}
+    CMAKE_ARGS     -DBUILD_GTEST=ON -DINSTALL_GTEST=ON -Dgtest_force_shared_crt=ON -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    LOG_DOWNLOAD   TRUE
+    LOG_CONFIGURE  TRUE
+    LOG_BUILD      TRUE
+    LOG_INSTALL    TRUE
+    BUILD_PROJECT  TRUE
+    ${UPDATE_DISCONNECTED_IF_AVAILABLE}
+  )
+  find_package(GTest REQUIRED)
+endif()
+
+# Benchmark dependencies
+if(BUILD_BENCHMARK)
+  # Google Benchmark (https://github.com/google/benchmark.git)
+  message(STATUS "Downloading and building Google Benchmark.")
+  if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$")
+    # hip-clang cannot compile googlebenchmark for some reason
+    set(COMPILER_OVERRIDE "-DCMAKE_CXX_COMPILER=g++")
+  endif()
+  # Download, build and install googlebenchmark library
+  set(GOOGLEBENCHMARK_ROOT ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark CACHE PATH "")
+  download_project(
+    PROJ           googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG        v1.4.0
+    INSTALL_DIR    ${GOOGLEBENCHMARK_ROOT}
+    CMAKE_ARGS     -DCMAKE_BUILD_TYPE=RELEASE -DBENCHMARK_ENABLE_TESTING=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> ${COMPILER_OVERRIDE}
+    LOG_DOWNLOAD   TRUE
+    LOG_CONFIGURE  TRUE
+    LOG_BUILD      TRUE
+    LOG_INSTALL    TRUE
+    BUILD_PROJECT  TRUE
+    ${UPDATE_DISCONNECTED_IF_AVAILABLE}
+  )
+  find_package(benchmark REQUIRED CONFIG PATHS ${GOOGLEBENCHMARK_ROOT})
+endif()
+
+# Find or download/install rocm-cmake project
+find_package(ROCM QUIET CONFIG PATHS /opt/rocm)
+if(NOT ROCM_FOUND)
+  set(rocm_cmake_tag "master" CACHE STRING "rocm-cmake tag to download")
+  file(
+    DOWNLOAD https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip
+    ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+    STATUS rocm_cmake_download_status LOG rocm_cmake_download_log
+  )
+  list(GET rocm_cmake_download_status 0 rocm_cmake_download_error_code)
+  if(rocm_cmake_download_error_code)
+    message(FATAL_ERROR "Error: downloading "
+      "https://github.com/RadeonOpenCompute/rocm-cmake/archive/${rocm_cmake_tag}.zip failed "
+      "error_code: ${rocm_cmake_download_error_code} "
+      "log: ${rocm_cmake_download_log} "
+    )
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    RESULT_VARIABLE rocm_cmake_unpack_error_code
+  )
+  if(rocm_cmake_unpack_error_code)
+    message(FATAL_ERROR "Error: unpacking  ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag}.zip failed")
+  endif()
+  find_package(ROCM REQUIRED CONFIG PATHS ${CMAKE_CURRENT_BINARY_DIR}/rocm-cmake-${rocm_cmake_tag})
+endif()
+
+include(ROCMSetupVersion)
+include(ROCMCreatePackage)
+include(ROCMInstallTargets)
+include(ROCMPackageConfigHelpers)
+include(ROCMInstallSymlinks)

--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,0 +1,27 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(${DL_ARGS_PROJ}-download NONE)
+
+include(ExternalProject)
+if(${DL_ARGS_BUILD_PROJECT})
+    ExternalProject_Add(${DL_ARGS_PROJ}-download
+                        ${DL_ARGS_UNPARSED_ARGUMENTS}
+                        SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
+                        BUILD_IN_SOURCE     TRUE
+                        TEST_COMMAND        ""
+    )
+else()
+    ExternalProject_Add(${DL_ARGS_PROJ}-download
+                        ${DL_ARGS_UNPARSED_ARGUMENTS}
+                        SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
+                        BUILD_IN_SOURCE     TRUE
+                        TEST_COMMAND        ""
+                        UPDATE_COMMAND      ""
+                        CONFIGURE_COMMAND   ""
+                        BUILD_COMMAND       ""
+                        INSTALL_COMMAND     ""
+    )
+endif()

--- a/cmake/DownloadProject.cmake
+++ b/cmake/DownloadProject.cmake
@@ -1,0 +1,170 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
+# MODULE:   DownloadProject
+#
+# PROVIDES:
+#   download_project( PROJ projectName
+#                    [PREFIX prefixDir]
+#                    [DOWNLOAD_DIR downloadDir]
+#                    [SOURCE_DIR srcDir]
+#                    [BINARY_DIR binDir]
+#                    [QUIET]
+#                    ...
+#   )
+#
+#       Provides the ability to download and unpack a tarball, zip file, git repository,
+#       etc. at configure time (i.e. when the cmake command is run). How the downloaded
+#       and unpacked contents are used is up to the caller, but the motivating case is
+#       to download source code which can then be included directly in the build with
+#       add_subdirectory() after the call to download_project(). Source and build
+#       directories are set up with this in mind.
+#
+#       The PROJ argument is required. The projectName value will be used to construct
+#       the following variables upon exit (obviously replace projectName with its actual
+#       value):
+#
+#           projectName_SOURCE_DIR
+#           projectName_BINARY_DIR
+#
+#       The SOURCE_DIR and BINARY_DIR arguments are optional and would not typically
+#       need to be provided. They can be specified if you want the downloaded source
+#       and build directories to be located in a specific place. The contents of
+#       projectName_SOURCE_DIR and projectName_BINARY_DIR will be populated with the
+#       locations used whether you provide SOURCE_DIR/BINARY_DIR or not.
+#
+#       The DOWNLOAD_DIR argument does not normally need to be set. It controls the
+#       location of the temporary CMake build used to perform the download.
+#
+#       The PREFIX argument can be provided to change the base location of the default
+#       values of DOWNLOAD_DIR, SOURCE_DIR and BINARY_DIR. If all of those three arguments
+#       are provided, then PREFIX will have no effect. The default value for PREFIX is
+#       CMAKE_BINARY_DIR.
+#
+#       The QUIET option can be given if you do not want to show the output associated
+#       with downloading the specified project.
+#
+#       In addition to the above, any other options are passed through unmodified to
+#       ExternalProject_Add() to perform the actual download, patch and update steps.
+#
+#       Only those ExternalProject_Add() arguments which relate to downloading, patching
+#       and updating of the project sources are intended to be used. Also note that at
+#       least one set of download-related arguments are required.
+#
+#       If using CMake 3.2 or later, the UPDATE_DISCONNECTED option can be used to
+#       prevent a check at the remote end for changes every time CMake is run
+#       after the first successful download. See the documentation of the ExternalProject
+#       module for more information. It is likely you will want to use this option if it
+#       is available to you. Note, however, that the ExternalProject implementation contains
+#       bugs which result in incorrect handling of the UPDATE_DISCONNECTED option when
+#       using the URL download method or when specifying a SOURCE_DIR with no download
+#       method. Fixes for these have been created, the last of which is scheduled for
+#       inclusion in CMake 3.8.0. Details can be found here:
+#
+#           https://gitlab.kitware.com/cmake/cmake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c
+#           https://gitlab.kitware.com/cmake/cmake/issues/16428
+#
+#       If you experience build errors related to the update step, consider avoiding
+#       the use of UPDATE_DISCONNECTED.
+#
+# EXAMPLE USAGE:
+#
+#   include(DownloadProject)
+#   download_project(PROJ                googletest
+#                    GIT_REPOSITORY      https://github.com/google/googletest.git
+#                    GIT_TAG             master
+#                    UPDATE_DISCONNECTED 1
+#                    QUIET
+#   )
+#
+#   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+#
+#========================================================================================
+
+
+set(_DownloadProjectDir "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeParseArguments)
+
+function(download_project)
+
+    set(options QUIET)
+    set(oneValueArgs
+        PROJ
+        PREFIX
+        DOWNLOAD_DIR
+        SOURCE_DIR
+        BINARY_DIR
+        BUILD_PROJECT
+    )
+    set(multiValueArgs "")
+
+    cmake_parse_arguments(DL_ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Hide output if requested
+    if (DL_ARGS_QUIET)
+        set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+        unset(OUTPUT_QUIET)
+        message(STATUS "Downloading/updating ${DL_ARGS_PROJ}")
+    endif()
+
+    # Set up where we will put our temporary CMakeLists.txt file and also
+    # the base point below which the default source and binary dirs will be.
+    # The prefix must always be an absolute path.
+    if (NOT DL_ARGS_PREFIX)
+        set(DL_ARGS_PREFIX "${CMAKE_BINARY_DIR}")
+    else()
+        get_filename_component(DL_ARGS_PREFIX "${DL_ARGS_PREFIX}" ABSOLUTE
+                               BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    if (NOT DL_ARGS_DOWNLOAD_DIR)
+        set(DL_ARGS_DOWNLOAD_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-download")
+    endif()
+
+    # Ensure the caller can know where to find the source and build directories
+    if (NOT DL_ARGS_SOURCE_DIR)
+        set(DL_ARGS_SOURCE_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-src")
+    endif()
+    if (NOT DL_ARGS_BINARY_DIR)
+        set(DL_ARGS_BINARY_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-build")
+    endif()
+    set(${DL_ARGS_PROJ}_SOURCE_DIR "${DL_ARGS_SOURCE_DIR}" PARENT_SCOPE)
+    set(${DL_ARGS_PROJ}_BINARY_DIR "${DL_ARGS_BINARY_DIR}" PARENT_SCOPE)
+
+    # The way that CLion manages multiple configurations, it causes a copy of
+    # the CMakeCache.txt to be copied across due to it not expecting there to
+    # be a project within a project.  This causes the hard-coded paths in the
+    # cache to be copied and builds to fail.  To mitigate this, we simply
+    # remove the cache if it exists before we configure the new project.  It
+    # is safe to do so because it will be re-generated.  Since this is only
+    # executed at the configure step, it should not cause additional builds or
+    # downloads.
+    file(REMOVE "${DL_ARGS_DOWNLOAD_DIR}/CMakeCache.txt")
+
+    # Create and build a separate CMake project to carry out the download.
+    # If we've already previously done these steps, they will not cause
+    # anything to be updated, so extra rebuilds of the project won't occur.
+    # Make sure to pass through CMAKE_MAKE_PROGRAM in case the main project
+    # has this set to something not findable on the PATH.
+    configure_file("${_DownloadProjectDir}/DownloadProject.CMakeLists.cmake.in"
+                   "${DL_ARGS_DOWNLOAD_DIR}/CMakeLists.txt")
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+                        -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+                        .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "CMake step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+                    RESULT_VARIABLE result
+                    ${OUTPUT_QUIET}
+                    WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "Build step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+endfunction()

--- a/cmake/Summary.cmake
+++ b/cmake/Summary.cmake
@@ -1,0 +1,39 @@
+# MIT License
+#
+# Copyright 2017-2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+function(print_configuration_summary)
+  message(STATUS "******** Summary ********")
+  message(STATUS "General:")
+  message(STATUS "  System                : ${CMAKE_SYSTEM_NAME}")
+  message(STATUS "  HIP ROOT              : ${HIP_ROOT_DIR}")
+  message(STATUS "  C++ compiler          : ${CMAKE_CXX_COMPILER}")
+  message(STATUS "  C++ compiler version  : ${CMAKE_CXX_COMPILER_VERSION}")
+  string(STRIP "${CMAKE_CXX_FLAGS}" CMAKE_CXX_FLAGS_STRIP)
+  message(STATUS "  CXX flags             : ${CMAKE_CXX_FLAGS_STRIP}")
+  message(STATUS "  Build type            : ${CMAKE_BUILD_TYPE}")
+  message(STATUS "  Install prefix        : ${CMAKE_INSTALL_PREFIX}")
+  message(STATUS "  Device targets        : ${AMDGPU_TARGETS}")
+  message(STATUS "")
+  message(STATUS "  BUILD_TEST            : ${BUILD_TEST}")
+  message(STATUS "  BUILD_BENCHMARK       : ${BUILD_BENCHMARK}")
+  message(STATUS "  BUILD_EXAMPLE         : ${BUILD_EXAMPLE}")
+endfunction()

--- a/cmake/VerifyCompiler.cmake
+++ b/cmake/VerifyCompiler.cmake
@@ -1,0 +1,62 @@
+# MIT License
+#
+# Copyright 2018-2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Find HIP package and verify that correct C++ compiler was selected for available
+# platfrom. On ROCm platform host and device code is compiled by the same compiler: hcc.
+
+# Find HIP package
+find_package(HIP 1.5.18263 REQUIRED) # 1.5.18263 is HIP version in ROCm 1.8.2
+
+if(HIP_PLATFORM STREQUAL "hcc")
+  if(NOT (CMAKE_CXX_COMPILER MATCHES ".*/hcc$" OR CMAKE_CXX_COMPILER MATCHES ".*/hipcc$"))
+    message(FATAL_ERROR "On ROCm platform 'hcc' or 'clang' must be used as C++ compiler.")
+  else()
+    # Determine if CXX Compiler is hcc, hip-clang or other
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} "--version" OUTPUT_VARIABLE CXX_OUTPUT
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_STRIP_TRAILING_WHITESPACE)
+    string(REGEX MATCH "[A-Za-z]* ?clang version" TMP_CXX_VERSION ${CXX_OUTPUT})
+    string(REGEX MATCH "[A-Za-z]+" CXX_VERSION_STRING ${TMP_CXX_VERSION})
+    if(CXX_VERSION_STRING MATCHES "HCC")
+        set(HIP_COMPILER "hcc" CACHE STRING "HIP Compiler")
+    elseif(CXX_VERSION_STRING MATCHES "clang")
+        set(HIP_COMPILER "clang" CACHE STRING "HIP Compiler")
+    else()
+        message(FATAL_ERROR "CXX Compiler version ${CXX_VERSION_STRING} unsupported.")
+    endif()
+    message(STATUS "HIP Compiler: " ${HIP_COMPILER})
+
+    # Workaround until hcc & hip cmake modules fixes symlink logic in their config files.
+    # (Thanks to rocBLAS devs for finding workaround for this problem.)
+    list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip)
+    # Ignore hcc warning: argument unused during compilation: '-isystem /opt/rocm/hip/include'
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
+    if(HIP_COMPILER STREQUAL "hcc")
+      find_package(hcc REQUIRED CONFIG PATHS /opt/rocm)
+    else()
+      find_package(hcc QUIET CONFIG PATHS /opt/rocm)
+    endif()
+    find_package(hip REQUIRED CONFIG PATHS /opt/rocm)
+  endif()
+else()
+  message(FATAL_ERROR "HIP_PLATFORM must be 'hcc' (AMD ROCm platform)")
+endif()

--- a/include/roclib_logging.hpp
+++ b/include/roclib_logging.hpp
@@ -9,7 +9,6 @@
 #include "roclib_tuple_helper.hpp"
 #include <atomic>
 #include <shared_mutex>
-#include <tuple>
 #include <unordered_map>
 
 /**********************************************************************
@@ -67,7 +66,7 @@ public:
         std::lock_guard<std::shared_timed_mutex> lock(mutex);
 
         // If tuple doesn't already exist, insert tuple arg by moving and 0
-        auto& ptr = map.emplace(std::move(arg), nullptr).first->second;
+        auto*& ptr = map.emplace(std::move(arg), nullptr).first->second;
 
         // If tuple existed, increment counter; otherwise allocate counter of 1
         if(ptr)

--- a/include/roclib_logging.hpp
+++ b/include/roclib_logging.hpp
@@ -1,0 +1,124 @@
+/* ************************************************************************
+ * Copyright 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#ifndef _ROCLIB_LOGGING_HPP_
+#define _ROCLIB_LOGGING_HPP_
+
+#include "roclib_ostream.hpp"
+#include "roclib_tuple_helper.hpp"
+#include <atomic>
+#include <shared_mutex>
+#include <tuple>
+#include <unordered_map>
+
+/**********************************************************************
+ * Log a list of 1 or more arguments, separating them with sep string *
+ **********************************************************************/
+template <typename H, typename... Ts>
+void roclib_log_arguments(roclib_ostream& os, const char* sep, H&& head, Ts&&... xs)
+{
+    os << std::forward<H>(head);
+    (void)(int[]){(os << sep << std::forward<Ts>(xs), 0)...};
+    os << std::endl;
+}
+
+/**********************************************************************
+ * Profile kernel arguments                                           *
+ **********************************************************************/
+template <typename TUP>
+class roclib_argument_profile
+{
+    // Output stream
+    roclib_ostream& os;
+
+    // Mutex for multithreaded access to table
+    std::shared_timed_mutex mutex;
+
+    // Table mapping argument tuples into atomic counts
+    std::unordered_map<TUP,
+                       std::atomic_size_t*,
+                       typename roclib_tuple_helper::hash_t<TUP>,
+                       typename roclib_tuple_helper::equal_t<TUP>>
+        map;
+
+public:
+    // A tuple of arguments is looked up in an unordered map.
+    // A count of the number of calls with these arguments is kept.
+    // arg is assumed to be an rvalue for efficiency
+    void operator()(TUP&& arg)
+    {
+        {
+            // Acquire a shared lock for reading map
+            std::shared_lock<std::shared_timed_mutex> lock(mutex);
+
+            // Look up the tuple in the map
+            auto p = map.find(arg);
+
+            // If tuple already exists, atomically increment count and return
+            if(p != map.end())
+            {
+                ++*p->second;
+                return;
+            }
+        } // Release shared lock
+
+        // Acquire an exclusive lock for modifying map
+        std::lock_guard<std::shared_timed_mutex> lock(mutex);
+
+        // If tuple doesn't already exist, insert tuple arg by moving and 0
+        auto& ptr = map.emplace(std::move(arg), nullptr).first->second;
+
+        // If tuple existed, increment counter; otherwise allocate counter of 1
+        if(ptr)
+            ++*ptr;
+        else
+            ptr = new std::atomic_size_t{1};
+    }
+
+    // Constructor
+    explicit roclib_argument_profile(const roclib_ostream& os)
+        : os(os.dup())
+    {
+    }
+
+    // Cleanup handler which dumps profile at destruction
+    ~roclib_argument_profile()
+    try
+    {
+        // Print all of the tuples in the map
+        for(auto& p : map)
+        {
+            os << "- ";
+            roclib_tuple_helper::print_tuple_pairs(
+                os, std::tuple_cat(p.first, std::make_tuple("call_count", p.second->load())));
+            os << "\n";
+            delete p.second;
+        }
+        os.flush();
+    }
+    catch(...)
+    {
+        return;
+    }
+};
+
+// log_profile will profile actual arguments, keeping count
+// of the number of times each set of arguments is used
+template <typename... Ts>
+void roclib_log_profile(roclib_ostream& os, Ts&&... xs)
+{
+    // Make a tuple with the arguments
+    auto tup = std::make_tuple(xs...);
+
+    // Set up profile
+    static roclib_argument_profile<decltype(tup)> profile(os);
+
+    // Add at_quick_exit handler in case the program exits early
+    static int aqe = at_quick_exit([] { profile.~roclib_argument_profile(); });
+
+    // Profile the tuple
+    profile(std::move(tup));
+}
+
+#endif

--- a/include/roclib_ostream.hpp
+++ b/include/roclib_ostream.hpp
@@ -393,12 +393,12 @@ public:
     {
         int fd     = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND | O_CLOEXEC, 0644);
         worker_ptr = get_worker(fd);
-        close(fd);
         if(!worker_ptr)
         {
             dprintf(STDERR_FILENO, "Cannot open %s: %m\n", filename);
             roclib_abort();
         }
+        close(fd);
     }
 
     // Construct from a std::string filename

--- a/include/roclib_ostream.hpp
+++ b/include/roclib_ostream.hpp
@@ -1,0 +1,685 @@
+/* ************************************************************************
+ * Copyright 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#ifndef _ROCLIB_OSTREAM_HPP_
+#define _ROCLIB_OSTREAM_HPP_
+
+#include <cmath>
+#include <complex>
+#include <condition_variable>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <fcntl.h>
+#include <future>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <thread>
+#include <type_traits>
+#include <unistd.h>
+#include <utility>
+
+/******************************************************************************
+ * roclib output streams                                                      *
+ ******************************************************************************/
+
+#define roclib_cout (roclib_ostream::cout())
+#define roclib_cerr (roclib_ostream::cerr())
+
+/******************************************************************************
+ * roclib_abort is a safe abort which flushes IO and avoids deadlock          *
+ ******************************************************************************/
+extern "C" void roclib_abort [[noreturn]] ();
+
+/******************************************************************************
+ * The roclib_ostream class performs atomic IO on log files, and provides     *
+ * consistent formatting                                                      *
+ ******************************************************************************/
+class roclib_ostream
+{
+    /**************************************************************************
+     * The worker class sets up a worker thread for writing output files. Two *
+     * files are considered the same if they have the same device ID / inode. *
+     **************************************************************************/
+    class worker
+    {
+        // task_t represents a payload of data and a promise to finish
+        class task_t
+        {
+            std::string        str;
+            std::promise<void> promise;
+
+        public:
+            // The task takes ownership of the string payload and promise
+            task_t(std::string&& str, std::promise<void>&& promise)
+                : str(std::move(str))
+                , promise(std::move(promise))
+            {
+            }
+
+            // Notify the future when the worker thread exits
+            void set_value_at_thread_exit()
+            {
+                promise.set_value_at_thread_exit();
+            }
+
+            // Notify the future immediately
+            void set_value()
+            {
+                promise.set_value();
+            }
+
+            // Size of the string payload
+            size_t size() const
+            {
+                return str.size();
+            }
+
+            // Data of the string payload
+            const char* data() const
+            {
+                return str.data();
+            }
+        };
+
+        // Worker thread which serializes data to be written to a device/inode
+        void worker_thread()
+        {
+            // Clear any errors in the FILE
+            clearerr(file);
+
+            // Lock the mutex in preparation for cond.wait
+            std::unique_lock<std::mutex> lock(mutex);
+
+            while(true)
+            {
+                // Wait for any data, ignoring spurious wakeups
+                cond.wait(lock, [&] { return !queue.empty(); });
+
+                // With the mutex locked, get and pop data from the front of queue
+                task_t task = std::move(queue.front());
+                queue.pop();
+
+                // Temporarily unlock queue mutex, unblocking other threads
+                lock.unlock();
+
+                // An empty message indicates the closing of the stream
+                if(!task.size())
+                {
+                    // Tell future to wake up after thread exits
+                    task.set_value_at_thread_exit();
+                    break;
+                }
+
+                // Write the data
+                fwrite(task.data(), 1, task.size(), file);
+
+                // Detect any error and flush the C FILE stream
+                if(ferror(file) || fflush(file))
+                {
+                    perror("Error writing log file");
+
+                    // Tell future to wake up after thread exits
+                    task.set_value_at_thread_exit();
+                    break;
+                }
+
+                // Promise that the data has been written
+                task.set_value();
+
+                // Re-lock the mutex in preparation for cond.wait
+                lock.lock();
+            }
+        }
+
+        /***********************
+         * Worker data members *
+         ***********************/
+
+        // FILE is used for safety in the presence of signals
+        FILE* file = nullptr;
+
+        // This worker's thread
+        std::thread thread;
+
+        // Condition variable for worker notification
+        std::condition_variable cond;
+
+        // Mutex for this thread's queue
+        std::mutex mutex;
+
+        // Queue of tasks
+        std::queue<task_t> queue;
+
+    public:
+        // Worker constructor creates a worker thread for a raw filehandle
+        explicit worker(int fd)
+        {
+            // The worker duplicates the file descriptor (RAII)
+            fd = fcntl(fd, F_DUPFD_CLOEXEC, 0);
+
+            // If the dup fails or fdopen fails, print error and abort
+            if(fd == -1 || !(file = fdopen(fd, "a")))
+            {
+                perror("fdopen() error");
+                roclib_abort();
+            }
+
+            // Create a worker thread, capturing *this
+            thread = std::thread([=] { worker_thread(); });
+
+            // Detatch from the worker thread
+            thread.detach();
+        }
+
+        // Send a string to the worker thread for this stream's device/inode
+        // Empty strings tell the worker thread to exit
+        void send(std::string str)
+        {
+            // Create a promise to wait for the operation to complete
+            std::promise<void> promise;
+
+            // The future indicating when the operation has completed
+            auto future = promise.get_future();
+
+            // task_t consists of string and promise
+            // std::move transfers ownership of str and promise to task
+            task_t worker_task(std::move(str), std::move(promise));
+
+            // Submit the task to the worker assigned to this device/inode
+            // Hold mutex for as short as possible, to reduce contention
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                queue.push(std::move(worker_task));
+            }
+
+            // Notify the worker that a new task was added
+            cond.notify_one();
+
+            // Wait for the task to be completed, to ensure flushed IO
+            future.get();
+        }
+
+        // Destroy a worker when all std::shared_ptr references to it are gone
+        ~worker()
+        {
+            // Tell worker thread to exit, by sending it an empty string
+            send({});
+
+            // Close the FILE
+            if(file)
+                fclose(file);
+        }
+    };
+
+    // Two filehandles point to the same file if they share the same (std_dev, std_ino).
+    // Initial slice of struct stat which contains device ID and inode
+    struct file_id_t
+    {
+        dev_t st_dev; // ID of device containing file
+        ino_t st_ino; // Inode number
+    };
+
+    // Compares device IDs and inodes for map containers
+    struct file_id_less
+    {
+        bool operator()(const file_id_t& lhs, const file_id_t& rhs) const
+        {
+            return lhs.st_ino < rhs.st_ino || (lhs.st_ino == rhs.st_ino && lhs.st_dev < rhs.st_dev);
+        }
+    };
+
+    // Map from file_id to a worker shared_ptr
+    // Implemented as singleton to avoid the static initialization order fiasco
+    static auto& map()
+    {
+        static std::map<file_id_t, std::shared_ptr<worker>, file_id_less> map;
+        return map;
+    }
+
+    // Mutex for accessing the map
+    // Implemented as singleton to avoid the static initialization order fiasco
+    static auto& map_mutex()
+    {
+        static std::recursive_mutex map_mutex;
+        return map_mutex;
+    }
+
+    // Get worker for writing to a file descriptor
+    static std::shared_ptr<worker> get_worker(int fd)
+    {
+        // For a file descriptor indicating an error, return a nullptr
+        if(fd == -1)
+            return nullptr;
+
+        // C++ allows type punning of common initial sequences
+        union
+        {
+            struct stat statbuf;
+            file_id_t   file_id;
+        };
+
+        // Verify common initial sequence
+        static_assert(std::is_standard_layout<file_id_t>{} && std::is_standard_layout<struct stat>{}
+                          && offsetof(file_id_t, st_dev) == 0 && offsetof(struct stat, st_dev) == 0
+                          && offsetof(file_id_t, st_ino) == offsetof(struct stat, st_ino)
+                          && std::is_same<decltype(file_id_t::st_dev), decltype(stat::st_dev)>{}
+                          && std::is_same<decltype(file_id_t::st_ino), decltype(stat::st_ino)>{},
+                      "struct stat and file_id_t are not layout-compatible");
+
+        // Get the device ID and inode, to detect common files
+        if(fstat(fd, &statbuf))
+        {
+            perror("Error executing fstat()");
+            return nullptr;
+        }
+
+        // Lock the map from file_id -> std::shared_ptr<roclib_ostream::worker>
+        std::lock_guard<std::recursive_mutex> lock(map_mutex());
+
+        // Insert a nullptr map element if file_id doesn't exist in map already
+        // worker_ptr is a reference to the std::shared_ptr<roclib_ostream::worker>
+        auto& worker_ptr = map().emplace(file_id, nullptr).first->second;
+
+        // If a new entry was inserted, or an old entry is empty, create new worker
+        if(!worker_ptr)
+            worker_ptr = std::make_shared<worker>(fd);
+
+        // Return the existing or new worker matching the file
+        return worker_ptr;
+    }
+
+    /*******************************
+     * roclib_ostream data members *
+     *******************************/
+
+    // Worker thread for accepting tasks
+    std::shared_ptr<worker> worker_ptr;
+
+    // Output buffer for formatted IO
+    std::ostringstream os;
+
+    // Flag indicating whether YAML mode is turned on
+    bool yaml = false;
+
+    // Abort function which is called only once by roclib_abort
+    static void roclib_abort_once [[noreturn]] ()
+    {
+        // Make sure the alarm and abort actions are default
+        signal(SIGALRM, SIG_DFL);
+        signal(SIGABRT, SIG_DFL);
+
+        // Unblock the alarm and abort signals
+        sigset_t set[1];
+        sigemptyset(set);
+        sigaddset(set, SIGALRM);
+        sigaddset(set, SIGABRT);
+        sigprocmask(SIG_UNBLOCK, set, nullptr);
+
+        // Timeout in case of deadlock
+        alarm(5);
+
+        // Obtain the map lock
+        map_mutex().lock();
+
+        // Clear the map, stopping all workers
+        map().clear();
+
+        // Flush all
+        fflush(nullptr);
+
+        // Abort
+        std::abort();
+    }
+
+    // Abort function which safely flushes all IO
+    friend void roclib_abort()
+    {
+        // If multiple threads call roclib_abort(), the first one wins
+        static int once = (roclib_abort_once(), 0);
+    }
+
+    // Private explicit copy constructor duplicates the worker and starts a new buffer
+    explicit roclib_ostream(const roclib_ostream& other)
+        : worker_ptr(other.worker_ptr)
+    {
+    }
+
+public:
+    // Default constructor is a std::ostringstream with no worker
+    roclib_ostream() = default;
+
+    // Move constructor
+    roclib_ostream(roclib_ostream&&) = default;
+
+    // Move assignment
+    roclib_ostream& operator=(roclib_ostream&&) = default;
+
+    // Copy assignment is deleted
+    roclib_ostream& operator=(const roclib_ostream&) = delete;
+
+    // Create a duplicate of this
+    roclib_ostream dup() const
+    {
+        if(!worker_ptr)
+            throw std::runtime_error(
+                "Attempting to duplicate a roclib_ostream without an associated file");
+        return roclib_ostream(*this);
+    }
+
+    // Construct roclib_ostream from a file descriptor
+    explicit roclib_ostream(int fd)
+        : worker_ptr(get_worker(fd))
+    {
+        if(!worker_ptr)
+        {
+            dprintf(STDERR_FILENO, "Error: Bad file descriptor %d\n", fd);
+            roclib_abort();
+        }
+    }
+
+    // Construct roclib_ostream from a filename opened for writing with truncation
+    explicit roclib_ostream(const char* filename)
+    {
+        int fd     = open(filename, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND | O_CLOEXEC, 0644);
+        worker_ptr = get_worker(fd);
+        close(fd);
+        if(!worker_ptr)
+        {
+            dprintf(STDERR_FILENO, "Cannot open %s: %m\n", filename);
+            roclib_abort();
+        }
+    }
+
+    // Construct from a std::string filename
+    explicit roclib_ostream(const std::string& filename)
+        : roclib_ostream(filename.c_str())
+    {
+    }
+
+    // Convert stream output to string
+    std::string str() const
+    {
+        return os.str();
+    }
+
+    // Clear the buffer
+    void clear()
+    {
+        os.clear();
+        os.str({});
+    }
+
+    // Flush the output
+    void flush()
+    {
+        // Flush only if this stream contains a worker (i.e., is not a string)
+        if(worker_ptr)
+        {
+            // The contents of the string buffer
+            auto str = os.str();
+
+            // Empty string buffers kill the worker thread, so they are not flushed here
+            if(str.size())
+                worker_ptr->send(std::move(str));
+
+            // Clear the string buffer
+            clear();
+        }
+    }
+
+    // Destroy the roclib_ostream
+    virtual ~roclib_ostream()
+    {
+        flush(); // Flush any pending IO
+    }
+
+    // Implemented as singleton to avoid the static initialization order fiasco
+    static roclib_ostream& cout()
+    {
+        thread_local roclib_ostream cout(STDOUT_FILENO);
+        return cout;
+    }
+
+    // Implemented as singleton to avoid the static initialization order fiasco
+    static roclib_ostream& cerr()
+    {
+        thread_local roclib_ostream cerr(STDERR_FILENO);
+        return cerr;
+    }
+
+private:
+    /*************************************************************************
+     * Non-member friend functions for formatted output                      *
+     *************************************************************************/
+
+    // Default output
+    template <typename T>
+    friend roclib_ostream& operator<<(roclib_ostream& os, T&& x)
+    {
+        os.os << std::forward<T>(x);
+        return os;
+    }
+
+    // Pairs for YAML output
+    template <typename T1, typename T2>
+    friend roclib_ostream& operator<<(roclib_ostream& os, std::pair<T1, T2> p)
+    {
+        os << p.first << ": ";
+        os.yaml = true;
+        os << p.second;
+        os.yaml = false;
+        return os;
+    }
+
+    // Floating-point output
+    template <int DIG, typename T>
+    roclib_ostream& print_floating_point(T val) &
+    {
+        if(!yaml)
+            os << val;
+        else
+        {
+            // For YAML, we must output the floating-point value exactly
+            double x{val};
+            if(std::isnan(x))
+                os << ".nan";
+            else if(std::isinf(x))
+                os << (x < 0 ? "-.inf" : ".inf");
+            else
+            {
+                char s[32];
+                snprintf(s, sizeof(s) - 2, "%.*g", DIG, x);
+
+                // If no decimal point or exponent, append .0 to indicate floating point
+                for(char* end = s; *end != '.' && *end != 'e' && *end != 'E'; ++end)
+                {
+                    if(!*end)
+                    {
+                        end[0] = '.';
+                        end[1] = '0';
+                        end[2] = '\0';
+                        break;
+                    }
+                }
+                os << s;
+            }
+        }
+        return *this;
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, double val)
+    {
+        return os.print_floating_point<17>(val);
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, float val)
+    {
+        return os.print_floating_point<9>(val);
+    }
+
+#ifdef ROCLIB_HALF
+    friend roclib_ostream& operator<<(roclib_ostream& os, ROCLIB_HALF val)
+    {
+        return os.print_floating_point<5>(val);
+    }
+#endif
+
+#ifdef ROCLIB_BF16
+    friend roclib_ostream& operator<<(roclib_ostream& os, ROCLIB_BF16 val)
+    {
+        return os.print_floating_point<4>(val);
+    }
+#endif
+
+    // Complex output
+    template <typename T>
+    roclib_ostream& print_complex(const T& z) &
+    {
+        if(yaml)
+        {
+            os << "'(";
+            *this << std::real(z);
+            os << ",";
+            *this << std::imag(z);
+            os << ")'";
+        }
+        else
+        {
+            os << z;
+        }
+        return *this;
+    }
+
+#ifdef ROCLIB_FLOAT_COMPLEX
+    friend roclib_ostream& operator<<(roclib_ostream& os, const ROCLIB_FLOAT_COMPLEX& z)
+    {
+        return os.print_complex(z);
+    }
+#endif
+
+#ifdef ROCLIB_DOUBLE_COMPLEX
+    friend roclib_ostream& operator<<(roclib_ostream& os, const ROCLIB_DOUBLE_COMPLEX& z)
+    {
+        return os.print_complex(z);
+    }
+#endif
+
+    // Integer output
+    friend roclib_ostream& operator<<(roclib_ostream& os, int32_t x)
+    {
+        return os.os << x, os;
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, uint32_t x)
+    {
+        return os.os << x, os;
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, int64_t x)
+    {
+        return os.os << x, os;
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, uint64_t x)
+    {
+        return os.os << x, os;
+    }
+
+    // bool output
+    friend roclib_ostream& operator<<(roclib_ostream& os, bool b)
+    {
+        if(os.yaml)
+            os.os << (b ? "true" : "false");
+        else
+            os.os << int(b);
+        return os;
+    }
+
+    // Character output
+    friend roclib_ostream& operator<<(roclib_ostream& os, char c)
+    {
+        if(os.yaml)
+        {
+            char s[]{c, 0};
+            os.os << std::quoted(s, '\'');
+        }
+        else
+            os.os << c;
+        return os;
+    }
+
+    // String output
+    friend roclib_ostream& operator<<(roclib_ostream& os, const char* s)
+    {
+        if(os.yaml)
+            os.os << std::quoted(s);
+        else
+            os.os << s;
+        return os;
+    }
+
+    friend roclib_ostream& operator<<(roclib_ostream& os, const std::string& s)
+    {
+        return os << s.c_str();
+    }
+
+    // Transfer roclib_ostream to std::ostream
+    friend std::ostream& operator<<(std::ostream& os, const roclib_ostream& str)
+    {
+        return os << str.str();
+    }
+
+    // Transfer roclib_ostream to roclib_ostream
+    friend roclib_ostream& operator<<(roclib_ostream& os, const roclib_ostream& str)
+    {
+        return os << str.str();
+    }
+
+    // IO Manipulators
+    friend roclib_ostream& operator<<(roclib_ostream& os, std::ostream& (*pf)(std::ostream&))
+    {
+        // Turn YAML formatting on or off
+        if(pf == roclib_ostream::yaml_on)
+            os.yaml = true;
+        else if(pf == roclib_ostream::yaml_off)
+            os.yaml = false;
+        else
+        {
+            // Output the manipulator to the buffer
+            os.os << pf;
+
+            // If the manipulator is std::endl or std::flush, flush the output
+            if(pf == static_cast<std::ostream& (*)(std::ostream&)>(std::endl)
+               || pf == static_cast<std::ostream& (*)(std::ostream&)>(std::flush))
+            {
+                os.flush();
+            }
+        }
+        return os;
+    }
+
+public:
+    // YAML Manipulators (only used for their addresses)
+    static std::ostream& yaml_on(std::ostream& os)
+    {
+        return os;
+    }
+
+    static std::ostream& yaml_off(std::ostream& os)
+    {
+        return os;
+    }
+};
+
+#endif

--- a/include/roclib_ostream.hpp
+++ b/include/roclib_ostream.hpp
@@ -299,19 +299,6 @@ class roclib_ostream
         return worker_ptr;
     }
 
-    /*******************************
-     * roclib_ostream data members *
-     *******************************/
-
-    // Worker thread for accepting tasks
-    std::shared_ptr<worker> worker_ptr;
-
-    // Output buffer for formatted IO
-    std::ostringstream os;
-
-    // Flag indicating whether YAML mode is turned on
-    bool yaml = false;
-
     // Abort function which is called only once by roclib_abort
     static void roclib_abort_once [[noreturn]] ()
     {
@@ -348,6 +335,19 @@ class roclib_ostream
         // If multiple threads call roclib_abort(), the first one wins
         static int once = (roclib_abort_once(), 0);
     }
+
+    /*******************************
+     * roclib_ostream data members *
+     *******************************/
+
+    // Worker thread for accepting tasks
+    std::shared_ptr<worker> worker_ptr;
+
+    // Output buffer for formatted IO
+    std::ostringstream os;
+
+    // Flag indicating whether YAML mode is turned on
+    bool yaml = false;
 
     // Private explicit copy constructor duplicates the worker and starts a new buffer
     explicit roclib_ostream(const roclib_ostream& other)

--- a/include/roclib_tuple_helper.hpp
+++ b/include/roclib_tuple_helper.hpp
@@ -1,0 +1,156 @@
+/* ************************************************************************
+ * Copyright 2020 Advanced Micro Devices, Inc.
+ * ************************************************************************ */
+
+#ifndef _ROCLIB_TUPLE_HELPER_HPP_
+#define _ROCLIB_TUPLE_HELPER_HPP_
+
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+/*****************************************************
+ * Tuple helper class provides operations on tuples  *
+ *****************************************************/
+class roclib_tuple_helper
+{
+    /********************************************************************
+     * Traverse (key, value) pairs, applying functions or printing YAML *
+     ********************************************************************/
+    template <typename FUNC, typename TUP, size_t... I>
+    static void apply_pairs_impl(FUNC&& func, const TUP& tuple, std::index_sequence<I...>)
+    {
+        // TODO: Replace with C++17 fold expression
+        // (func(std::get<I * 2>(tuple), std::get<I * 2 + 1>(tuple)), ...);
+        (void)(int[]){(func(std::get<I * 2>(tuple), std::get<I * 2 + 1>(tuple)), 0)...};
+    }
+
+public:
+    // Apply a function to pairs in a tuple (name1, value1, name2, value2, ...)
+    template <typename FUNC, typename TUP>
+    static void apply_pairs(FUNC&& func, const TUP& tuple)
+    {
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
+        apply_pairs_impl(std::forward<FUNC>(func),
+                         tuple,
+                         std::make_index_sequence<std::tuple_size<TUP>{} / 2>{});
+    }
+
+    // Print a tuple which is expected to be (name1, value1, name2, value2, ...)
+    template <typename IOS, typename TUP>
+    static IOS& print_tuple_pairs(IOS& os, const TUP& tuple)
+    {
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
+
+        // delim starts as "{ " and becomes ", " afterwards
+        auto print_pair = [&, delim = "{ "](const char* name, const auto& value) mutable {
+            os << delim << std::make_pair(name, value);
+            delim = ", ";
+        };
+
+        // Call print_argument for each (name, value) tuple pair
+        apply_pairs(print_pair, tuple);
+
+        // Closing brace
+        return os << " }\n";
+    }
+
+    /*********************************************************************
+     * Compute value hashes for (key1, value1, key2, value2, ...) tuples *
+     *********************************************************************/
+    // Default hash for non-enum types
+    template <typename T, std::enable_if_t<!std::is_enum<T>{}, int> = 0>
+    static size_t hash(const T& x)
+    {
+        return std::hash<T>{}(x);
+    }
+
+    // Workaround for compilers which don't implement C++14 enum hash
+    template <typename T, std::enable_if_t<std::is_enum<T>{}, int> = 0>
+    static size_t hash(const T& x)
+    {
+        return std::hash<typename std::underlying_type<T>::type>{}(x);
+    }
+
+    // C-style string hash since std::hash does not hash them
+    static size_t hash(const char* s)
+    {
+        size_t seed = 0xcbf29ce484222325;
+        for(auto p = reinterpret_cast<const unsigned char*>(s); *p; ++p)
+            seed = (seed ^ *p) * 0x100000001b3; // FNV-1a
+        return seed;
+    }
+
+    // For std::string consistency with above
+    static size_t hash(const std::string& s)
+    {
+        return hash(s.c_str());
+    }
+
+    // Iterate over pairs, combining hash values
+    template <typename TUP, size_t... I>
+    static size_t hash(const TUP& tuple, std::index_sequence<I...>)
+    {
+        size_t seed = 0;
+        for(size_t h : {hash(std::get<I * 2 + 1>(tuple))...})
+            seed ^= h + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        return seed;
+    }
+
+    // Hash function class compatible with STL containers
+    template <typename TUP>
+    struct hash_t
+    {
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
+        size_t operator()(const TUP& tuple) const
+        {
+            return hash(tuple, std::make_index_sequence<std::tuple_size<TUP>{} / 2>{});
+        }
+    };
+
+    /************************************************************************
+     * Test (key1, value1, key2, value2, ...) tuples for equality of values *
+     ************************************************************************/
+private:
+    // Default comparison
+    template <typename T>
+    static bool equal(const T& x1, const T& x2)
+    {
+        return x1 == x2;
+    }
+
+    // C-string == C-string
+    static bool equal(const char* s1, const char* s2)
+    {
+        return !strcmp(s1, s2);
+    }
+
+    // Compute equality of values in tuple (name, value) pairs
+    template <typename TUP, size_t... I>
+    static bool equal(const TUP& t1, const TUP& t2, std::index_sequence<I...>)
+    {
+        // TODO: Replace with C++17 fold expression
+        // return(equal(std::get<I * 2 + 1>(t1), std::get<I * 2 + 1>(t2)) && ...);
+        bool ret = true;
+        (void)(bool[]){(ret = ret && equal(std::get<I * 2 + 1>(t1), std::get<I * 2 + 1>(t2)))...};
+        return ret;
+    }
+
+public:
+    // Tuple (name, value) equality test class is compatible with STL associative containers
+    template <typename TUP>
+    struct equal_t
+    {
+        static_assert(std::tuple_size<TUP>{} % 2 == 0, "Tuple size must be even");
+        bool operator()(const TUP& t1, const TUP& t2) const
+        {
+            return equal(t1, t2, std::make_index_sequence<std::tuple_size<TUP>{} / 2>{});
+        }
+    };
+};
+
+#endif


### PR DESCRIPTION
This is a work in progress... This is just an initial draft, showing the direction towards a common header-only library. 

It changes `rocblas_` prefixes to `roclib_` (should that be changed to the plural `roclibs_` ?).

It refactors the thread-safe `rocblas_ostream` -> `roclib_ostream` output code into a single header file.

It uses `ROCLIB_*` macros which can be defined by clients prior to `#include`ing the header, to specify things such as half-precision, bfloat16, and complex types, and then the output will be defined for those types, assuming those types meet certain minimum requirements.

It also pulls the most common parts of the logging code which can have applicability to other projects, while keeping the rocBLAS-specific parts of logging inside of rocBLAS (I am editing another branch of rocBLAS while editing this one, moving code from rocBLAS to here).

I copied and edited some of the CMake stuff from rocPRIM as @saadrahim suggested, but I still need to modify it to get it to build. The repo directory structure might need to be changed slightly.

@feizheng10 @malcolmroberts @evetsso  @doctorcolinsmith @amcamd @bragadeesh 